### PR TITLE
fix: timing for placing atom

### DIFF
--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -246,7 +246,7 @@ def extrande(
         return KMCResult()
 
     logger.info(f"Reaction {chosen_recipe.get_recipe_name()} was chose at time {t}")
-    logger.debug(f"\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
+    logger.debug(f"\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
     return KMCResult(
         recipe=chosen_recipe,
         reaction_probability=None,

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -225,7 +225,7 @@ def extrande(
     n_extra = 0
     while t < t_max:
         crr_window_idx = np.searchsorted(boarders, t, side="right") - 1
-        b = max(rate_sums[crr_window_idx:crr_window_idx+1])
+        b = max(rate_sums[crr_window_idx : crr_window_idx + 1])
         l = t_max - t
 
         tau = tau_scale * rng.exponential(1 / b)

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -225,7 +225,7 @@ def extrande(
     n_extra = 0
     while t < t_max:
         crr_window_idx = np.searchsorted(boarders, t, side="right") - 1
-        b = max(rate_sums[crr_window_idx : crr_window_idx + 1])
+        b = max(rate_sums[crr_window_idx:])
         l = t_max - t
 
         tau = tau_scale * rng.exponential(1 / b)

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -213,22 +213,31 @@ def extrande(
     # time of last rate, should be last MD time
     t_max = boarders[-1]
 
-    n_extra = 0
+    rate_sums = [sum(l) for l in rate_windows]
+    idx_rate_max = np.argmax(rate_sums)
+    expected_tau = np.mean(tau_scale * rng.exponential(1 / max(rate_sums), 10))
+    logger.debug(
+        f"Max of summed rate of {rate_sums[idx_rate_max]:.2} between t "
+        f"{boarders[idx_rate_max]} - {boarders[idx_rate_max+1]}\n"
+        f"\t\texpected tau: {expected_tau}"
+    )
 
+    n_extra = 0
     while t < t_max:
         crr_window_idx = np.searchsorted(boarders, t, side="right") - 1
-        b = max([sum(l) for l in rate_windows[crr_window_idx:]])
+        b = max(rate_sums[crr_window_idx:crr_window_idx+1])
         l = t_max - t
 
         tau = tau_scale * rng.exponential(1 / b)
-        logger.debug(
-            f"Extrande stats:\nTau:\t{tau}\nl:\t\t{l}\nt_max:\t{t_max}\nb:\t\t{b}"
-        )
         if tau > l:
             # reject
             logger.info(
                 "Tau exceeded simulation frame, no reaction to perform.\n"
                 f"accepted: 0, rejected: 1, extra: {n_extra}"
+            )
+            logger.debug(
+                f"Extrande stats:\n\tb:\t\t{b}\n\tTau:\t{tau}"
+                f"\n\tl:\t\t{l}\n\tt:\t\t{t}\n\tt_max:\t{t_max}"
             )
             return KMCResult()
 
@@ -246,12 +255,18 @@ def extrande(
 
         # Extra reaction channel, repeat for new t
         n_extra += 1
-        logger.info(f"Extra reaction channel was chose at time {t}")
-        logger.debug(f"Extrande stats:\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
+        if n_extra == len(boarders * 1000):
+            logger.warning(
+                f"{n_extra} extra reactions performed during extrande KMC calculation. Try increasing tau_scale"
+            )
 
     if chosen_recipe is None:
         logger.info(
-            "No reaction was chosen\n" f"accepted: 0, rejected: 1, extra: {n_extra}"
+            f"No reaction was chosen\naccepted: 0, rejected: 1, extra: {n_extra}"
+        )
+        logger.debug(
+            f"Extrande stats:\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}"
+            f"\n\tTau:\t{tau}\n\tl:\t\t{l}\n\tt:\t\t{t}\n\tt_max:\t{t_max}"
         )
         return KMCResult()
 
@@ -259,7 +274,10 @@ def extrande(
         f"Reaction {chosen_recipe.get_recipe_name()} was chose at time {t}\n"
         f"accepted: 1, rejected: 0, extra: {n_extra}"
     )
-    logger.debug(f"Extrande stats:\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
+    logger.debug(
+        f"Extrande stats:\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}"
+        f"\n\tTau:\t{tau}\n\tl:\t\t{l}\n\tt:\t\t{t}\n\tt_max:\t{t_max}"
+    )
     return KMCResult(
         recipe=chosen_recipe,
         reaction_probability=None,

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -213,6 +213,8 @@ def extrande(
     # time of last rate, should be last MD time
     t_max = boarders[-1]
 
+    n_extra = 0
+
     while t < t_max:
         crr_window_idx = np.searchsorted(boarders, t, side="right") - 1
         b = max([sum(l) for l in rate_windows[crr_window_idx:]])
@@ -221,8 +223,11 @@ def extrande(
         tau = tau_scale * rng.exponential(1 / b)
         if tau > l:
             # reject
-            logger.info("Tau exceeded simulation frame, no reaction to perform.")
-            logger.debug(f"Tau:\t{tau}\nl:\t{l}\nt_max:\t{t_max}\nb:\t{b}")
+            logger.info(
+                "Tau exceeded simulation frame, no reaction to perform.\n"
+                f"accepted: 0, rejected: 1, extra: {n_extra}"
+            )
+            logger.debug(f"\nTau:\t{tau}\nl:\t{l}\nt_max:\t{t_max}\nb:\t{b}")
             return KMCResult()
 
         t += tau
@@ -238,14 +243,20 @@ def extrande(
             break
 
         # Extra reaction channel, repeat for new t
+        n_extra += 1
         logger.info(f"Extra reaction channel was chose at time {t}")
-        logger.debug(f"\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
+        logger.debug(f"\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
 
     if chosen_recipe is None:
-        logger.info("No reaction was chosen")
+        logger.info(
+            "No reaction was chosen\n" f"accepted: 0, rejected: 1, extra: {n_extra}"
+        )
         return KMCResult()
 
-    logger.info(f"Reaction {chosen_recipe.get_recipe_name()} was chose at time {t}")
+    logger.info(
+        f"Reaction {chosen_recipe.get_recipe_name()} was chose at time {t}\n"
+        f"accepted: 1, rejected: 0, extra: {n_extra}"
+    )
     logger.debug(f"\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
     return KMCResult(
         recipe=chosen_recipe,

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -221,13 +221,15 @@ def extrande(
         l = t_max - t
 
         tau = tau_scale * rng.exponential(1 / b)
+        logger.debug(
+            f"Extrande stats:\nTau:\t{tau}\nl:\t\t{l}\nt_max:\t{t_max}\nb:\t\t{b}"
+        )
         if tau > l:
             # reject
             logger.info(
                 "Tau exceeded simulation frame, no reaction to perform.\n"
                 f"accepted: 0, rejected: 1, extra: {n_extra}"
             )
-            logger.debug(f"\nTau:\t{tau}\nl:\t{l}\nt_max:\t{t_max}\nb:\t{b}")
             return KMCResult()
 
         t += tau
@@ -245,7 +247,7 @@ def extrande(
         # Extra reaction channel, repeat for new t
         n_extra += 1
         logger.info(f"Extra reaction channel was chose at time {t}")
-        logger.debug(f"\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
+        logger.debug(f"Extrande stats:\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
 
     if chosen_recipe is None:
         logger.info(
@@ -257,7 +259,7 @@ def extrande(
         f"Reaction {chosen_recipe.get_recipe_name()} was chose at time {t}\n"
         f"accepted: 1, rejected: 0, extra: {n_extra}"
     )
-    logger.debug(f"\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
+    logger.debug(f"Extrande stats:\n\ta0:\t\t{a0}\n\tb:\t\t{b}\n\tb*u:\t{b*u}")
     return KMCResult(
         recipe=chosen_recipe,
         reaction_probability=None,

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -224,7 +224,7 @@ class Recipe:
         Reaction rates corresponding 1:1 to timespans.
     timespans : list[list[float, float]]
         List of half-open timespans (t1, t2] in ps, at which this rate is valid.
-        Recipe steps which change the coordinates only need to be applicable 
+        Recipe steps which change the coordinates only need to be applicable
         at the first time in the interval.
         Must have same number of timespans as rates.
         t1 can equal t2 for the last frame.

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -470,6 +470,7 @@ class RecipeCollection:
                 # the selected recipe must tell where it should be applied
                 re_copy = copy(re)
                 re_copy.timespans = [ts]
+                re_copy.rates = [r]
                 [l.append(r) for l in rate_windows[left_idx:right_idx]]
                 [l.append(re_copy) for l in recipe_windows[left_idx:right_idx]]
 

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -7,6 +7,7 @@ from abc import ABC
 from dataclasses import dataclass, field
 from pathlib import Path
 import logging
+from copy import copy
 import dill
 import csv
 import numpy as np
@@ -222,9 +223,11 @@ class Recipe:
     rates : list[float]
         Reaction rates corresponding 1:1 to timespans.
     timespans : list[list[float, float]]
-        List of half-open timespans (t1, t2] in ps, at which this reaction
-        path applies. Must have same number of timespans as rates.
-        t1 can equal t2 for the first frame.
+        List of half-open timespans (t1, t2] in ps, at which this rate is valid.
+        Recipe steps which change the coordinates only need to be applicable 
+        at the first time in the interval.
+        Must have same number of timespans as rates.
+        t1 can equal t2 for the last frame.
 
     """
 
@@ -463,8 +466,12 @@ class RecipeCollection:
             for r, ts in zip(re.rates, re.timespans):
                 left_idx = boarders.index(ts[0])
                 right_idx = boarders.index(ts[1])
+                # timespan <- boarder
+                # the selected recipe must tell where it should be applied
+                re_copy = copy(re)
+                re_copy.timespans = [ts]
                 [l.append(r) for l in rate_windows[left_idx:right_idx]]
-                [l.append(re) for l in recipe_windows[left_idx:right_idx]]
+                [l.append(re_copy) for l in recipe_windows[left_idx:right_idx]]
 
         return boarders, rate_windows, recipe_windows
 

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -516,7 +516,12 @@ class RunManager:
         logger.debug(f"Performing recipe steps:\n{pformat(recipe.recipe_steps)}")
 
         # Set time to chosen 'time_start' of KMCResult
-        truncate_sim_files(files, self.kmcresult.time_start)
+        ttime = self.kmcresult.time_start
+        if any([isinstance(step, Place) for step in recipe.recipe_steps]):
+            # only first time of interval is valid for placement
+            ttime = recipe.timespans[0][0]
+
+        truncate_sim_files(files, ttime)
 
         top_initial = deepcopy(self.top)
         for step in recipe.recipe_steps:

--- a/tests/test_kmc.py
+++ b/tests/test_kmc.py
@@ -35,8 +35,8 @@ def reference_extrande_KMC() -> KMCResult:
     return KMCResult(
         recipe=Recipe(
             [Break(3, 4), Bind(4, 5)],
-            rates=[0.15, 0.06],
-            timespans=[(2.0, 4.0), (4.0, 8.0)],
+            rates=[0.15],
+            timespans=[(2.0, 4.0)],
         ),
         time_delta=0,
         time_start=3.9741815791575505,


### PR DESCRIPTION
When place is in the recipe, only one single time the reaction is valid. The rate can be valid until the next rate is calculated though. 
Therefore, when a reaction-window that uses `place` is chosen, the reaction should be executed at the time of the rate calculation, which is the first time of the timespan.