### PR TITLE
fix: make forcefield directory optional, only warn

### DIFF
--- a/src/kimmdy/config.py
+++ b/src/kimmdy/config.py
@@ -223,12 +223,13 @@ class Config:
                         f"Found {len(ffs)} forcefields in cwd, using first one: {ffs[0]}"
                     )
                 if len(ffs) == 0:
-                    m = f"Found 0 forcefields in cwd. Please specify a forcefield to be used from the gromacs directory or add a .ff folder to the cwd."
-                    self._logmessages["errors"].append(m)
-                    raise FileNotFoundError(m)
-                ffdir = ffs[0].resolve()
-                assert ffdir.is_dir(), "Forcefield should be a directory!"
-            elif not ffdir.exists():
+                    m = f"Found 0 forcefields in cwd. Please specify a forcefield to be used from the gromacs directory or add a .ff folder to the cwd or preceed at your own risk."
+                    self._logmessages["warnings"].append(m)
+                    ffdir = None
+                else:
+                    ffdir = ffs[0].resolve()
+                    assert ffdir.is_dir(), "Forcefield should be a directory!"
+            elif ffdir is not None and not ffdir.exists():
                 gmxdir = get_gmx_dir(self.gromacs_alias)
                 if gmxdir is None:
                     self._logmessages["warnings"].append(


### PR DESCRIPTION
for non-conventional systems that bring all their parameters with their topology instead of providing a protein forcefield directory