### PR TITLE
fix: update dihedrals, make pairs unique

### DIFF
--- a/src/kimmdy/topology/topology.py
+++ b/src/kimmdy/topology/topology.py
@@ -495,7 +495,8 @@ class MoleculeType:
         """
 
         update_map = {
-            atom_nr: str(i + 1) for i, atom_nr in enumerate(self.atoms.keys())
+            atom_nr: str(i + 1)
+            for i, atom_nr in enumerate(sorted(list(self.atoms.keys()), key=int))
         }
 
         new_atoms = {}

--- a/src/kimmdy/topology/topology.py
+++ b/src/kimmdy/topology/topology.py
@@ -539,8 +539,8 @@ class MoleculeType:
 
         new_pairs = {}
         new_multiple_dihedrals = {}
-        new_dihedrals = {}
         for dihedrals in self.proper_dihedrals.values():
+            new_dihedrals = {}
             ai = update_map.get(dihedrals.ai)
             aj = update_map.get(dihedrals.aj)
             ak = update_map.get(dihedrals.ak)
@@ -550,9 +550,10 @@ class MoleculeType:
                 continue
 
             # do pairs before the dihedrals are updated
-            if pair := self.pairs.get((dihedrals.ai, dihedrals.al)):
+            if pair := self.pairs.pop((dihedrals.ai, dihedrals.al), False):
                 pair_ai = update_map.get(pair.ai)
                 pair_aj = update_map.get(pair.aj)
+
                 if None not in (pair_ai, pair_aj):
                     pair.ai = pair_ai  # type: ignore (pyright bug)
                     pair.aj = pair_aj  # type: ignore
@@ -569,6 +570,7 @@ class MoleculeType:
                 dihedral.ak = ak  # type: ignore
                 dihedral.al = al  # type: ignore
                 new_dihedrals[dihedral.periodicity] = dihedral
+            dihedrals.dihedrals = new_dihedrals
 
             new_multiple_dihedrals[
                 (

--- a/src/kimmdy/topology/topology.py
+++ b/src/kimmdy/topology/topology.py
@@ -978,11 +978,23 @@ class Topology:
                 f"{float(self.atoms[atom.bound_to_nrs[0]].charge) + float(atom.charge):7.4f}"
             )
 
-            # break all bonds and delete all pairs, diheadrals etc
+            # break all bonds and delete all pairs, diheadrals with these bonds
             for bound_nr in copy(atom.bound_to_nrs):
                 self.break_bond((bound_nr, _atom_nr))
-            self.radicals.pop(_atom_nr)
 
+            for an in tuple(self.angles.keys()):
+                if _atom_nr in an:
+                    self.angles.pop(an)
+
+            for pd in tuple(self.proper_dihedrals.keys()):
+                if _atom_nr in pd:
+                    self.proper_dihedrals.pop(pd)
+
+            for id in tuple(self.improper_dihedrals.keys()):
+                if _atom_nr in id:
+                    self.improper_dihedrals.pop(id)
+
+            self.radicals.pop(_atom_nr)
             self.atoms.pop(_atom_nr)
 
         update_map_all = self.reindex_atomnrs()

--- a/src/kimmdy/topology/topology.py
+++ b/src/kimmdy/topology/topology.py
@@ -585,21 +585,31 @@ class MoleculeType:
         self.proper_dihedrals = new_multiple_dihedrals
         self.pairs = new_pairs
 
-        new_impropers = {}
-        for dihedral in self.improper_dihedrals.values():
-            ai = update_map.get(dihedral.ai)
-            aj = update_map.get(dihedral.aj)
-            ak = update_map.get(dihedral.ak)
-            al = update_map.get(dihedral.al)
+        new_multiple_dihedrals = {}
+        for dihedrals in self.improper_dihedrals.values():
+            new_dihedrals = {}
+            ai = update_map.get(dihedrals.ai)
+            aj = update_map.get(dihedrals.aj)
+            ak = update_map.get(dihedrals.ak)
+            al = update_map.get(dihedrals.al)
             # drop dihedrals to a deleted atom
             if None in (ai, aj, ak, al):
                 continue
-            dihedral.ai = ai  # type: ignore
-            dihedral.aj = aj  # type: ignore
-            dihedral.ak = ak  # type: ignore
-            dihedral.al = al  # type: ignore
-            new_impropers[(ai, aj, ak, al)] = dihedral
-        self.improper_dihedrals = new_impropers
+            dihedrals.ai = ai  # type: ignore
+            dihedrals.aj = aj  # type: ignore
+            dihedrals.ak = ak  # type: ignore
+            dihedrals.al = al  # type: ignore
+
+            for dihedral in dihedrals.dihedrals.values():
+                dihedral.ai = ai  # type: ignore
+                dihedral.aj = aj  # type: ignore
+                dihedral.ak = ak  # type: ignore
+                dihedral.al = al  # type: ignore
+                new_dihedrals[dihedral.periodicity] = dihedral
+            dihedrals.dihedrals = new_dihedrals
+
+            new_multiple_dihedrals[(ai, aj, ak, al)] = dihedrals
+        self.improper_dihedrals = new_multiple_dihedrals
 
         return update_map
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -252,16 +252,64 @@ class TestTopAB:
 
 
 class TestTopology:
+
+    def test_reindex_no_change(self, hexala_top_fix: Topology):
+        org_top: Topology = deepcopy(hexala_top_fix)
+        update = hexala_top_fix.reindex_atomnrs()
+
+        # test produced mapping
+        assert len(update.keys()) == 12
+        for mapping in update.values():
+            for k, v in mapping.items():
+                assert k == v
+
+        # test topology
+        assert org_top.atoms == hexala_top_fix.atoms
+        assert org_top.bonds == hexala_top_fix.bonds
+        assert org_top.angles == hexala_top_fix.angles
+        assert org_top.proper_dihedrals == hexala_top_fix.proper_dihedrals
+        assert org_top.improper_dihedrals == hexala_top_fix.improper_dihedrals
+
+    def test_reindex(self, hexala_top_fix: Topology):
+        org_top: Topology = deepcopy(hexala_top_fix)
+        hexala_top_fix.del_atom()
+
     @given(atomindex=st.integers(min_value=1, max_value=72))
     @settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=400)
     def test_del_atom_hexala(self, hexala_top_fix, atomindex):
         top: Topology = deepcopy(hexala_top_fix)
 
         atom = top.atoms[str(atomindex)]
+        # bonds
         bound_nrs = deepcopy(atom.bound_to_nrs)
         bound_atms = [top.atoms[i] for i in bound_nrs]
+        # angles
+        angles_to_delete = []
+        angles_to_update = []
+        for key in top.angles.keys():
+            if str(atomindex) in key:
+                angles_to_delete.append(key)
+            else:
+                angles_to_update.append(key)
+        # proper dihedrals
+        pd_to_delete = []
+        pd_to_update = []
+        for key in top.proper_dihedrals.keys():
+            if str(atomindex) in key:
+                pd_to_delete.append(key)
+            else:
+                pd_to_update.append(key)
+        # improper dihedrals
+        id_to_delete = []
+        id_to_update = []
+        for key in top.improper_dihedrals.keys():
+            if str(atomindex) in key:
+                id_to_delete.append(key)
+            else:
+                id_to_update.append(key)
 
-        top.del_atom(str(atomindex), parameterize=False)
+        update = top.del_atom(str(atomindex), parameterize=False)
+        rev_update = {v: k for k, v in update.items()}
 
         for nr, atm in zip(bound_nrs, bound_atms):
             if int(nr) > atomindex:
@@ -272,6 +320,55 @@ class TestTopology:
 
         assert atom not in top.atoms.values()
         assert len(atom.bound_to_nrs) == 0
+
+        # angles
+        for a_del in angles_to_delete:
+            assert top.angles.get(a_del) is None
+        for a_up in angles_to_update:
+            new = top.angles[tuple([update.get(a) for a in a_up])]
+            old = hexala_top_fix.angles[a_up]
+            assert old.ai == rev_update.get(new.ai)
+            assert old.aj == rev_update.get(new.aj)
+            assert old.ak == rev_update.get(new.ak)
+
+        # proper dihedrals
+        for pd_del in pd_to_delete:
+            assert top.proper_dihedrals.get(pd_del) is None
+        for pd_up in pd_to_update:
+            new = top.proper_dihedrals[tuple([update.get(a) for a in pd_up])]
+            old = hexala_top_fix.proper_dihedrals[pd_up]
+            assert old.ai == rev_update.get(new.ai)
+            assert old.aj == rev_update.get(new.aj)
+            assert old.ak == rev_update.get(new.ak)
+            assert old.al == rev_update.get(new.al)
+
+            for d_key in old.dihedrals:
+                old_d = old.dihedrals[d_key]
+                new_d = new.dihedrals[d_key]
+                assert new_d.ai == update.get(old_d.ai)
+                assert new_d.aj == update.get(old_d.aj)
+                assert new_d.ak == update.get(old_d.ak)
+                assert new_d.al == update.get(old_d.al)
+
+        # TODO: Activate once #387 is merged
+        # # improper dihedrals
+        # for id_del in pd_to_delete:
+        #     assert top.improper_dihedrals.get(id_del) is None
+        # for id_up in pd_to_update:
+        #     new = top.improper_dihedrals[tuple([update.get(a) for a in id_up])]
+        #     old = hexala_top_fix.improper_dihedrals[id_up]
+        #     assert old.ai == rev_update.get(new.ai)
+        #     assert old.aj == rev_update.get(new.aj)
+        #     assert old.ak == rev_update.get(new.ak)
+        #     assert old.al == rev_update.get(new.al)
+
+        #     for d_key in old.dihedrals:
+        #         old_d = old.dihedrals[d_key]
+        #         new_d = new.dihedrals[d_key]
+        #         assert new_d.ai == update.get(old_d.ai)
+        #         assert new_d.aj == update.get(old_d.aj)
+        #         assert new_d.ak == update.get(old_d.ak)
+        #         assert new_d.al == update.get(old_d.al)
 
     def test_break_bind_bond_hexala(self, hexala_top_fix):
         top = deepcopy(hexala_top_fix)

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -270,10 +270,6 @@ class TestTopology:
         assert org_top.proper_dihedrals == hexala_top_fix.proper_dihedrals
         assert org_top.improper_dihedrals == hexala_top_fix.improper_dihedrals
 
-    def test_reindex(self, hexala_top_fix: Topology):
-        org_top: Topology = deepcopy(hexala_top_fix)
-        hexala_top_fix.del_atom()
-
     @given(atomindex=st.integers(min_value=1, max_value=72))
     @settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=400)
     def test_del_atom_hexala(self, hexala_top_fix, atomindex):
@@ -323,7 +319,7 @@ class TestTopology:
 
         # angles
         for a_del in angles_to_delete:
-            assert top.angles.get(a_del) is None
+            assert None in [update.get(a) for a in a_del]
         for a_up in angles_to_update:
             new = top.angles[tuple([update.get(a) for a in a_up])]
             old = hexala_top_fix.angles[a_up]
@@ -333,7 +329,7 @@ class TestTopology:
 
         # proper dihedrals
         for pd_del in pd_to_delete:
-            assert top.proper_dihedrals.get(pd_del) is None
+            assert None in tuple([update.get(a) for a in pd_del])
         for pd_up in pd_to_update:
             new = top.proper_dihedrals[tuple([update.get(a) for a in pd_up])]
             old = hexala_top_fix.proper_dihedrals[pd_up]
@@ -353,7 +349,7 @@ class TestTopology:
         # TODO: Activate once #387 is merged
         # # improper dihedrals
         # for id_del in pd_to_delete:
-        #     assert top.improper_dihedrals.get(id_del) is None
+        #     assert None in tuple([update.get(a) for a in id_del])
         # for id_up in pd_to_update:
         #     new = top.improper_dihedrals[tuple([update.get(a) for a in id_up])]
         #     old = hexala_top_fix.improper_dihedrals[id_up]

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -346,25 +346,24 @@ class TestTopology:
                 assert new_d.ak == update.get(old_d.ak)
                 assert new_d.al == update.get(old_d.al)
 
-        # TODO: Activate once #387 is merged
-        # # improper dihedrals
-        # for id_del in pd_to_delete:
-        #     assert None in tuple([update.get(a) for a in id_del])
-        # for id_up in pd_to_update:
-        #     new = top.improper_dihedrals[tuple([update.get(a) for a in id_up])]
-        #     old = hexala_top_fix.improper_dihedrals[id_up]
-        #     assert old.ai == rev_update.get(new.ai)
-        #     assert old.aj == rev_update.get(new.aj)
-        #     assert old.ak == rev_update.get(new.ak)
-        #     assert old.al == rev_update.get(new.al)
+        # improper dihedrals
+        for id_del in id_to_delete:
+            assert None in tuple([update.get(a) for a in id_del])
+        for id_up in id_to_update:
+            new = top.improper_dihedrals[tuple([update.get(a) for a in id_up])]
+            old = hexala_top_fix.improper_dihedrals[id_up]
+            assert old.ai == rev_update.get(new.ai)
+            assert old.aj == rev_update.get(new.aj)
+            assert old.ak == rev_update.get(new.ak)
+            assert old.al == rev_update.get(new.al)
 
-        #     for d_key in old.dihedrals:
-        #         old_d = old.dihedrals[d_key]
-        #         new_d = new.dihedrals[d_key]
-        #         assert new_d.ai == update.get(old_d.ai)
-        #         assert new_d.aj == update.get(old_d.aj)
-        #         assert new_d.ak == update.get(old_d.ak)
-        #         assert new_d.al == update.get(old_d.al)
+            for d_key in old.dihedrals:
+                old_d = old.dihedrals[d_key]
+                new_d = new.dihedrals[d_key]
+                assert new_d.ai == update.get(old_d.ai)
+                assert new_d.aj == update.get(old_d.aj)
+                assert new_d.ak == update.get(old_d.ak)
+                assert new_d.al == update.get(old_d.al)
 
     def test_break_bind_bond_hexala(self, hexala_top_fix):
         top = deepcopy(hexala_top_fix)


### PR DESCRIPTION
Fixes #376 

There were two problems. 

Inner dihedrals in MultipleDihedrals were all written in the same dict (new_dihedrals), for all multidihedrals. Did not matter though, as this dict was not fed back into the multidihedrals.

Second, multiple dihedrals had the same start and end, with different middle atoms. The start and end were used for pairs, leading to duplicate definitions of the same pair. On top, the pair was updated, so it got updated a second time, leading to a miss match of dict keys and content in the pairs.

https://github.com/hits-mbm-dev/kimmdy/blob/9f9b162c40aaf91f691b3963578030592f0ec0a5/src/kimmdy/topology/topology.py#L529-L567

