### PR TITLE
multipledihedrals for impropers

### DIFF
--- a/src/kimmdy/topology/atomic.py
+++ b/src/kimmdy/topology/atomic.py
@@ -559,17 +559,18 @@ class ResidueBondSpec:
 
 @dataclass()
 class ResidueImproperSpec:
-    """Information about one imroper dihedral in a residue
+    """Information about one improper dihedral in a residue
 
-    ; atom1 atom2 atom3 atom4 q0 cq
+    ; atom1 atom2 atom3 atom4 c0(q0) c1(cp) c2(mult)
     """
 
     atom1: str
     atom2: str
     atom3: str
     atom4: str
-    q0: Optional[str]
-    cq: Optional[str]
+    c0: Optional[str]
+    c1: Optional[str]
+    c2: Optional[str]
 
     @classmethod
     def from_top_line(cls, l: list[str]):
@@ -578,23 +579,26 @@ class ResidueImproperSpec:
             atom2=l[1],
             atom3=l[2],
             atom4=l[3],
-            q0=field_or_none(l, 4),
-            cq=field_or_none(l, 5),
+            c0=field_or_none(l, 4),
+            c1=field_or_none(l, 5),
+            c2=field_or_none(l, 6),
         )
 
 
 @dataclass()
 class ResidueProperSpec:
-    """Information about one imroper dihedral in a residue
+    """Information about one proper dihedral in a residue
 
-    ; atom1 atom2 atom3 atom4 q0 cq
+    ; atom1 atom2 atom3 atom4 c0(q0) c1(cq) c2
     """
 
     atom1: str
     atom2: str
     atom3: str
     atom4: str
-    q0: Optional[str]
+    c0: Optional[str]
+    c1: Optional[str]
+    c2: Optional[str]
 
     @classmethod
     def from_top_line(cls, l: list[str]):
@@ -603,7 +607,9 @@ class ResidueProperSpec:
             atom2=l[1],
             atom3=l[2],
             atom4=l[3],
-            q0=field_or_none(l, 4),
+            c0=field_or_none(l, 4),
+            c1=field_or_none(l, 5),
+            c2=field_or_none(l, 6),
         )
 
 

--- a/src/kimmdy/topology/topology.py
+++ b/src/kimmdy/topology/topology.py
@@ -267,7 +267,9 @@ class MoleculeType:
             attributes_to_list(x)
             for dihedrals in self.proper_dihedrals.values()
             for x in dihedrals.dihedrals.values()
-        ] + [attributes_to_list(x) for x in self.improper_dihedrals.values()]
+        ] + [attributes_to_list(x) 
+            for dihedrals in self.improper_dihedrals.values()
+            for x in dihedrals.dihedrals.values()]
         self.atomics["position_restraints"] = [
             attributes_to_list(x) for x in self.position_restraints.values()
         ]

--- a/src/kimmdy/topology/topology.py
+++ b/src/kimmdy/topology/topology.py
@@ -267,9 +267,11 @@ class MoleculeType:
             attributes_to_list(x)
             for dihedrals in self.proper_dihedrals.values()
             for x in dihedrals.dihedrals.values()
-        ] + [attributes_to_list(x) 
+        ] + [
+            attributes_to_list(x)
             for dihedrals in self.improper_dihedrals.values()
-            for x in dihedrals.dihedrals.values()]
+            for x in dihedrals.dihedrals.values()
+        ]
         self.atomics["position_restraints"] = [
             attributes_to_list(x) for x in self.position_restraints.values()
         ]

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -145,7 +145,9 @@ def test_merge_prm_top(arranged_tmp_path):
     assert top_merge.bonds[("26", "27")].funct == "3"
     assert top_merge.angles[("17", "19", "20")].c3 is not None
     assert top_merge.proper_dihedrals[("15", "17", "19", "24")].dihedrals["3"].c5 == "3"
-    assert top_merge.improper_dihedrals[("17", "20", "19", "24")].c5 == "2"
+    assert (
+        top_merge.improper_dihedrals[("17", "20", "19", "24")].dihedrals["2"].c5 == "2"
+    )
     # assert one dihedral merge improper/proper
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -47,6 +47,7 @@ def test_integration_valid_input_files(arranged_tmp_path):
 def test_grompp_with_kimmdy_topology(arranged_tmp_path):
     raw_top = read_top(Path("minimal.top"))
     top = Topology(raw_top)
+    top_dict = top.to_dict()
     write_top(top.to_dict(), Path("output.top"))
     assert sp.run(
         [


### PR DESCRIPTION
due to how grappa works, impropers should be multipledihedrals. This should not affect regular amber99sb runs.